### PR TITLE
Fix an error where the value returned was not in double's scope

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/account/Account.java
+++ b/src/main/java/com/greatmancode/craftconomy3/account/Account.java
@@ -389,6 +389,10 @@ public class Account {
 	 * @return The formatted double
 	 */
 	public static double format(double value) {
+		if (value == Double.MAX_VALUE) {
+			return value;
+		}
+		
 		long factor = (long) Math.pow(10, 2);
 		value = value * factor;
 		double tmp = Math.floor(value);


### PR DESCRIPTION
When provided with Double.MAX_VALUE, the formatting method breaks completely - it returns Double.POSITIVE_INFINITY, which other methods can't really parse. (At least, BigDecimal doesn't like it)

This pull request stops the formatting of such numbers.
