### PR TITLE
Fix the /money log command with MySQL backend

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
@@ -63,7 +63,7 @@ public class LogTable extends DatabaseTable {
     public final String selectEntryLimit = "SELECT * FROM " + getPrefix() + TABLE_NAME + " " +
             "LEFT JOIN " + getPrefix() + AccountTable.TABLE_NAME + " " +
             "ON " + getPrefix() + TABLE_NAME + ".username_id = " + getPrefix() + AccountTable.TABLE_NAME + ".id " +
-            "WHERE " + getPrefix() + AccountTable.TABLE_NAME + ".name=? ORDER BY " + TABLE_NAME + ".id LIMIT ?,?";
+            "WHERE " + getPrefix() + AccountTable.TABLE_NAME + ".name=? ORDER BY " + getPrefix() + TABLE_NAME + ".id LIMIT ?,?";
 
     public final String cleanEntry = "DELETE FROM " + getPrefix() + TABLE_NAME + " WHERE timestamp <= ?";
 

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
@@ -63,7 +63,7 @@ public class LogTable extends DatabaseTable {
     public final String selectEntryLimit = "SELECT * FROM " + getPrefix() + TABLE_NAME + " " +
             "LEFT JOIN " + getPrefix() + AccountTable.TABLE_NAME + " " +
             "ON " + getPrefix() + TABLE_NAME + ".username_id = " + getPrefix() + AccountTable.TABLE_NAME + ".id " +
-            "WHERE " + getPrefix() + AccountTable.TABLE_NAME + ".name=? LIMIT ?,? ORDER BY " + TABLE_NAME + ".id";
+            "WHERE " + getPrefix() + AccountTable.TABLE_NAME + ".name=? ORDER BY " + TABLE_NAME + ".id LIMIT ?,?";
 
     public final String cleanEntry = "DELETE FROM " + getPrefix() + TABLE_NAME + " WHERE timestamp <= ?";
 


### PR DESCRIPTION
This fixes a bug in the LogTable's selectEntryLimit() method which resulted in the /money log command from spitting out this error then run:

```
[20:29:54] [Server thread/INFO]: Phoenix616 issued server command: /money log
[20:29:54] [Server thread/WARN]: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ORDER BY log.id' at line 1
[20:29:54] [Server thread/WARN]:        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[20:29:54] [Server thread/WARN]:        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[20:29:54] [Server thread/WARN]:        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[20:29:54] [Server thread/WARN]:        at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.Util.handleNewInstance(Util.java:407)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.Util.getInstance(Util.java:382)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:1052)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3593)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3525)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:1986)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2140)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2626)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:2111)
[20:29:54] [Server thread/WARN]:        at com.mysql.jdbc.PreparedStatement.executeQuery(PreparedStatement.java:2273)
[20:29:54] [Server thread/WARN]:        at com.greatmancode.com.zaxxer.hikari.proxy.PreparedStatementProxy.executeQuery(PreparedStatementProxy.java:44)
[20:29:54] [Server thread/WARN]:        at com.greatmancode.craftconomy3.storage.sql.SQLStorageEngine.getLog(SQLStorageEngine.java:687)
[20:29:54] [Server thread/WARN]:        at com.greatmancode.craftconomy3.commands.money.LogCommandThread.run(LogCommand.java:58)
[20:29:54] [Server thread/WARN]:        at org.bukkit.craftbukkit.v1_8_R1.scheduler.CraftTask.run(CraftTask.java:71)
[20:29:54] [Server thread/WARN]:        at org.bukkit.craftbukkit.v1_8_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:350)
[20:29:54] [Server thread/WARN]:        at net.minecraft.server.v1_8_R1.MinecraftServer.z(MinecraftServer.java:698)
[20:29:54] [Server thread/WARN]:        at net.minecraft.server.v1_8_R1.DedicatedServer.z(DedicatedServer.java:316)
[20:29:54] [Server thread/WARN]:        at net.minecraft.server.v1_8_R1.MinecraftServer.y(MinecraftServer.java:623)
[20:29:54] [Server thread/WARN]:        at net.minecraft.server.v1_8_R1.MinecraftServer.run(MinecraftServer.java:526)
[20:29:54] [Server thread/WARN]:        at java.lang.Thread.run(Thread.java:745)
```

It also adds a missing getPrefix() to the table's name at the same location.