### PR TITLE
Fixed: slf4j class not found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ dependencies {
     compile group: 'com.greatmancode', name: 'tools', version:'1.3-SNAPSHOT'
     compile group: 'com.zaxxer', name: 'HikariCP', version:'2.4.3'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.12'
+    compile group: 'org.slf4j', name: 'slf4j-simple', version:'1.7.12'
     compile group: 'com.h2database', name: 'h2', version:'1.4.187'
     compile group: 'org.xerial', name: 'sqlite-jdbc', version:'3.7.15-M1'
     testCompile group: 'junit', name: 'junit', version:'4.11'
@@ -120,6 +121,7 @@ shadowJar {
         include(dependency('com.greatmancode:tools:1.3-SNAPSHOT'))
         include(dependency('com.zaxxer:HikariCP:2.4.3'))
         include(dependency('org.slf4j:slf4j-api:1.7.12'))
+        include(dependency('org.slf4j:slf4j-simple:1.7.12'))
         include(dependency('com.h2database:h2:1.4.187'))
         include(dependency('com.googlecode.json-simple:json-simple:1.1'))
     }


### PR DESCRIPTION
I fixed the missing class slf4j by adding a new dependency : slf4j-simple.
It concerns #111 #77 #76 and all other duplicates.
I hope it's a good way for doing this. It works well.