### PR TITLE
Fixed: /bank list empty with username and upper case

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/SQLStorageEngine.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/SQLStorageEngine.java
@@ -708,7 +708,7 @@ public abstract class SQLStorageEngine extends StorageEngine {
         try {
             connection = (commitConnection != null) ? commitConnection : db.getConnection();
             statement = connection.prepareStatement(accessTable.getAccountList);
-            statement.setString(1, sender);
+            statement.setString(1, sender.toLowerCase());
             ResultSet set = statement.executeQuery();
             while (set.next()) {
                 results.add(set.getString("name"));


### PR DESCRIPTION
When using an uppercase name like "Aztorius", /bank list return an empty list.
Fixed using method toLowerCase as it is saved lowercase in database.
Issues related : #85 