### PR TITLE
Add UTF-8 charset for MySQL database

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/AccessTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/AccessTable.java
@@ -31,8 +31,8 @@ public class AccessTable extends DatabaseTable {
             "  `acl` BOOLEAN DEFAULT FALSE," +
             "  `withdraw` BOOLEAN DEFAULT FALSE," +
             "  PRIMARY KEY (`account_id`, `playerName`)," +
-            "  CONSTRAINT `"+getPrefix()+"fk_acl_account` FOREIGN KEY (`account_id`) REFERENCES `" + getPrefix() + AccountTable.TABLE_NAME + "` (`id`) ON UPDATE CASCADE ON DELETE CASCADE" +
-            ") ENGINE=InnoDB;";
+            "  CONSTRAINT `" + getPrefix() + "fk_acl_account` FOREIGN KEY (`account_id`) REFERENCES `" + getPrefix() + AccountTable.TABLE_NAME + "` (`id`) ON UPDATE CASCADE ON DELETE CASCADE" +
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `account_id` int(11)," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/AccountTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/AccountTable.java
@@ -30,8 +30,8 @@ public class AccountTable extends DatabaseTable {
             "  `ignoreACL` boolean DEFAULT FALSE," +
             "  `bank` boolean DEFAULT FALSE," +
             "  PRIMARY KEY (id)," +
-            "  KEY `"+getPrefix()+"account_name_index` (`name`(50))" +
-            ") ENGINE=InnoDB;";
+            "  KEY `" + getPrefix() + "account_name_index` (`name`(50))" +
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS " + getPrefix() + TABLE_NAME + " (" +
             "id int PRIMARY KEY AUTO_INCREMENT," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/BalanceTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/BalanceTable.java
@@ -38,7 +38,7 @@ public class BalanceTable extends DatabaseTable {
             "  CONSTRAINT `"+getPrefix()+"fk_balance_currency`" +
             "    FOREIGN KEY (" + CURRENCY_FIELD + ")" +
             "    REFERENCES " + getPrefix() + CurrencyTable.TABLE_NAME +"(name) ON UPDATE CASCADE ON DELETE CASCADE" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS " + getPrefix() + TABLE_NAME + " (" +
             "  `" + BALANCE_FIELD + "` double DEFAULT NULL," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/ConfigTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/ConfigTable.java
@@ -28,7 +28,7 @@ public class ConfigTable extends DatabaseTable {
             "  `" + NAME_FIELD + "` varchar(30) NOT NULL," +
             "  `" + VALUE_FIELD + "` varchar(255) NOT NULL," +
             "  PRIMARY KEY (`"+NAME_FIELD+"`)" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `" + NAME_FIELD + "` varchar(30) NOT NULL," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/CurrencyTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/CurrencyTable.java
@@ -31,7 +31,7 @@ public class CurrencyTable extends DatabaseTable {
             "  `status` BOOLEAN DEFAULT FALSE," +
             "  `bankCurrency` BOOLEAN DEFAULT FALSE," +
             "  PRIMARY KEY (`name`)" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `name` varchar(50)," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/ExchangeTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/ExchangeTable.java
@@ -33,7 +33,7 @@ public class ExchangeTable extends DatabaseTable {
             "  CONSTRAINT `"+getPrefix()+"fk_exchange_currencyto`" +
             "    FOREIGN KEY (to_currency)" +
             "    REFERENCES " + getPrefix() + CurrencyTable.TABLE_NAME + " (name) ON UPDATE CASCADE ON DELETE CASCADE" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `from_currency` VARCHAR(50) NOT NULL," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/LogTable.java
@@ -34,7 +34,7 @@ public class LogTable extends DatabaseTable {
             "  PRIMARY KEY (`id`)," +
             "  CONSTRAINT `"+getPrefix()+"fk_log_account` FOREIGN KEY (`username_id`) REFERENCES `" + getPrefix() + AccountTable.TABLE_NAME + "` (`id`) ON DELETE CASCADE," +
             "  CONSTRAINT `"+getPrefix()+"fk_log_currency` FOREIGN KEY (`currency_id`) REFERENCES `" + getPrefix() + CurrencyTable.TABLE_NAME + "` (`name`) ON DELETE CASCADE" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `id` int(11) NOT NULL AUTO_INCREMENT," +

--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/WorldGroupTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/WorldGroupTable.java
@@ -26,7 +26,7 @@ public class WorldGroupTable extends DatabaseTable {
             "  `groupName` varchar(255)," +
             "  `worldList` varchar(255)," +
             "  PRIMARY KEY (`groupName`)" +
-            ") ENGINE=InnoDB;";
+            ") ENGINE=InnoDB CHARSET=utf8;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `groupName` varchar(255)," +


### PR DESCRIPTION
This fix some issues with Russian languages and many more.
It is also a critical change, but it should not break old databases as it don't recreate them.
So only new databases would benefit from this change and will fix the charset issue.