### PR TITLE
Quick fix when creating tables with UTF-8

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/WorldGroupTable.java
+++ b/src/main/java/com/greatmancode/craftconomy3/storage/sql/tables/WorldGroupTable.java
@@ -26,7 +26,7 @@ public class WorldGroupTable extends DatabaseTable {
             "  `groupName` varchar(255)," +
             "  `worldList` varchar(255)," +
             "  PRIMARY KEY (`groupName`)" +
-            ") ENGINE=InnoDB CHARSET=utf8;";
+            ") ENGINE=InnoDB;";
 
     public final String createTableH2 = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + TABLE_NAME + "` (" +
             "  `groupName` varchar(255)," +


### PR DESCRIPTION
Should fix #120 .
The WorldGroup table elements can be higher than 767 characters because of UTF-8.
So this must be the only one where we disable UTF-8. It should not break things.